### PR TITLE
Introduce JobStatus and read data from stream

### DIFF
--- a/lib/helpers.go
+++ b/lib/helpers.go
@@ -2,9 +2,10 @@ package lib
 
 import (
 	"github.com/flavioribeiro/snickers/db"
+	"github.com/flavioribeiro/snickers/types"
 )
 
-func ChangeJobStatus(jobID string, newStatus string) {
+func ChangeJobStatus(jobID string, newStatus types.JobStatus) {
 	dbInstance, _ := db.GetDatabase()
 	job, _ := dbInstance.RetrieveJob(jobID)
 	job.Status = newStatus

--- a/rest/job_handlers.go
+++ b/rest/job_handlers.go
@@ -3,7 +3,6 @@ package rest
 import (
 	"encoding/json"
 	"fmt"
-	"io/ioutil"
 	"net/http"
 
 	"github.com/dchest/uniuri"
@@ -24,9 +23,7 @@ func CreateJob(w http.ResponseWriter, r *http.Request) {
 	}
 
 	var jobInput types.JobInput
-	respData, err := ioutil.ReadAll(r.Body)
-	err = json.Unmarshal(respData, &jobInput)
-	if err != nil {
+	if err := json.NewDecoder(r.Body).Decode(&jobInput); err != nil {
 		HTTPError(w, http.StatusBadRequest, "unpacking job", err)
 		return
 	}

--- a/rest/preset_handlers.go
+++ b/rest/preset_handlers.go
@@ -3,7 +3,6 @@ package rest
 import (
 	"encoding/json"
 	"fmt"
-	"io/ioutil"
 	"net/http"
 
 	"github.com/flavioribeiro/snickers/db"
@@ -22,9 +21,7 @@ func CreatePreset(w http.ResponseWriter, r *http.Request) {
 	}
 
 	var preset types.Preset
-	respData, err := ioutil.ReadAll(r.Body)
-	err = json.Unmarshal(respData, &preset)
-	if err != nil {
+	if err := json.NewDecoder(r.Body).Decode(&preset); err != nil {
 		HTTPError(w, http.StatusBadRequest, "unpacking preset", err)
 		return
 	}
@@ -48,9 +45,7 @@ func UpdatePreset(w http.ResponseWriter, r *http.Request) {
 	}
 
 	var preset types.Preset
-	respData, err := ioutil.ReadAll(r.Body)
-	err = json.Unmarshal(respData, &preset)
-	if err != nil {
+	if err := json.NewDecoder(r.Body).Decode(&preset); err != nil {
 		HTTPError(w, http.StatusBadRequest, "unpacking preset", err)
 		return
 	}

--- a/tests/rest_preset_test.go
+++ b/tests/rest_preset_test.go
@@ -15,27 +15,27 @@ import (
 )
 
 var _ = Describe("Rest API", func() {
-	Context("/presets location", func() {
-		var (
-			response   *httptest.ResponseRecorder
-			server     *mux.Router
-			dbInstance db.DatabaseInterface
-		)
+	var (
+		response   *httptest.ResponseRecorder
+		server     *mux.Router
+		dbInstance db.DatabaseInterface
+	)
 
-		BeforeEach(func() {
-			response = httptest.NewRecorder()
-			server = rest.NewRouter()
-			dbInstance, _ = db.GetDatabase()
-			dbInstance.ClearDatabase()
-		})
+	BeforeEach(func() {
+		response = httptest.NewRecorder()
+		server = rest.NewRouter()
+		dbInstance, _ = db.GetDatabase()
+		dbInstance.ClearDatabase()
+	})
 
-		It("GET should return application/json on its content type", func() {
+	Describe("GET /presets", func() {
+		It("should return application/json on its content type", func() {
 			request, _ := http.NewRequest("GET", "/presets", nil)
 			server.ServeHTTP(response, request)
 			Expect(response.HeaderMap["Content-Type"][0]).To(Equal("application/json; charset=UTF-8"))
 		})
 
-		It("GET should return stored presets", func() {
+		It("should return stored presets", func() {
 			examplePreset1 := types.Preset{Name: "a"}
 			examplePreset2 := types.Preset{Name: "b"}
 			dbInstance.StorePreset(examplePreset1)
@@ -51,53 +51,10 @@ var _ = Describe("Rest API", func() {
 			Expect(response.Code).To(Equal(http.StatusOK))
 			Expect(responseBody).To(SatisfyAny(Equal(expected1), Equal(expected2)))
 		})
+	})
 
-		It("POST should save a new preset", func() {
-			preset := []byte(`{"name": "storedPreset", "video": {},"audio": {}}`)
-			request, _ := http.NewRequest("POST", "/presets", bytes.NewBuffer(preset))
-			server.ServeHTTP(response, request)
-
-			presets, _ := dbInstance.GetPresets()
-			Expect(response.Code).To(Equal(http.StatusOK))
-			Expect(response.HeaderMap["Content-Type"][0]).To(Equal("application/json; charset=UTF-8"))
-			Expect(len(presets)).To(Equal(1))
-		})
-
-		It("POST with malformed preset should return bad request", func() {
-			preset := []byte(`{"neime: "badPreset}}`)
-			request, _ := http.NewRequest("POST", "/presets", bytes.NewBuffer(preset))
-			server.ServeHTTP(response, request)
-
-			Expect(response.Code).To(Equal(http.StatusBadRequest))
-			Expect(response.HeaderMap["Content-Type"][0]).To(Equal("application/json; charset=UTF-8"))
-		})
-
-		It("PUT with a new preset should update the preset", func() {
-			dbInstance.StorePreset(types.Preset{Name: "examplePreset"})
-			preset := []byte(`{"name":"examplePreset","Description": "new description","video": {},"audio": {}}`)
-
-			request, _ := http.NewRequest("PUT", "/presets", bytes.NewBuffer(preset))
-			server.ServeHTTP(response, request)
-
-			presets, _ := dbInstance.GetPresets()
-			newPreset := presets[0]
-			Expect(response.Code).To(Equal(http.StatusOK))
-			Expect(response.HeaderMap["Content-Type"][0]).To(Equal("application/json; charset=UTF-8"))
-			Expect(newPreset.Description).To(Equal("new description"))
-		})
-
-		It("PUT with malformed preset should return bad request", func() {
-			dbInstance.StorePreset(types.Preset{Name: "examplePreset"})
-			preset := []byte(`{"name":"examplePreset","Description: "new description","video": {},"audio": {}}`)
-
-			request, _ := http.NewRequest("PUT", "/presets", bytes.NewBuffer(preset))
-			server.ServeHTTP(response, request)
-
-			Expect(response.Code).To(Equal(http.StatusBadRequest))
-			Expect(response.HeaderMap["Content-Type"][0]).To(Equal("application/json; charset=UTF-8"))
-		})
-
-		It("GET for a given preset should return preset details", func() {
+	Describe("GET /presets/:name", func() {
+		It("should return the preset with details", func() {
 			examplePreset := types.Preset{
 				Name:         "examplePreset",
 				Description:  "This is an example of preset",
@@ -130,15 +87,69 @@ var _ = Describe("Rest API", func() {
 			Expect(response.Body.String()).To(Equal(string(expected)))
 		})
 
-		It("GET to /presets/presetName should return BadRequest if the preset doesn't exist", func() {
-			request, _ := http.NewRequest("GET", "/presets/yoyoyo", nil)
+		Context("when getting the preset fails", func() {
+			It("should return BadRequest", func() {
+				request, _ := http.NewRequest("GET", "/presets/yoyoyo", nil)
+				server.ServeHTTP(response, request)
+				expected, _ := json.Marshal(`{"error": "retrieving preset: preset not found"}`)
+				responseBody, _ := json.Marshal(string(response.Body.String()))
+				Expect(responseBody).To(Equal(expected))
+				Expect(response.Code).To(Equal(http.StatusBadRequest))
+				Expect(response.HeaderMap["Content-Type"][0]).To(Equal("application/json; charset=UTF-8"))
+			})
+		})
+	})
+
+	Describe("POST /presets", func() {
+		It("should save a new preset", func() {
+			preset := []byte(`{"name": "storedPreset", "video": {},"audio": {}}`)
+			request, _ := http.NewRequest("POST", "/presets", bytes.NewBuffer(preset))
 			server.ServeHTTP(response, request)
-			expected, _ := json.Marshal(`{"error": "retrieving preset: preset not found"}`)
-			responseBody, _ := json.Marshal(string(response.Body.String()))
-			Expect(responseBody).To(Equal(expected))
-			Expect(response.Code).To(Equal(http.StatusBadRequest))
+
+			presets, _ := dbInstance.GetPresets()
+			Expect(response.Code).To(Equal(http.StatusOK))
 			Expect(response.HeaderMap["Content-Type"][0]).To(Equal("application/json; charset=UTF-8"))
+			Expect(len(presets)).To(Equal(1))
 		})
 
+		Context("when the request is invalid", func() {
+			It("should return BadRequest if preset is malformed", func() {
+				preset := []byte(`{"neime: "badPreset}}`)
+				request, _ := http.NewRequest("POST", "/presets", bytes.NewBuffer(preset))
+				server.ServeHTTP(response, request)
+
+				Expect(response.Code).To(Equal(http.StatusBadRequest))
+				Expect(response.HeaderMap["Content-Type"][0]).To(Equal("application/json; charset=UTF-8"))
+			})
+		})
+	})
+
+	Describe("PUT /presets", func() {
+		It("should update an existing preset", func() {
+			dbInstance.StorePreset(types.Preset{Name: "examplePreset"})
+			preset := []byte(`{"name":"examplePreset","Description": "new description","video": {},"audio": {}}`)
+
+			request, _ := http.NewRequest("PUT", "/presets", bytes.NewBuffer(preset))
+			server.ServeHTTP(response, request)
+
+			presets, _ := dbInstance.GetPresets()
+			newPreset := presets[0]
+			Expect(response.Code).To(Equal(http.StatusOK))
+			Expect(response.HeaderMap["Content-Type"][0]).To(Equal("application/json; charset=UTF-8"))
+			Expect(newPreset.Description).To(Equal("new description"))
+		})
+
+		Context("when the request is invalid", func() {
+			It("should return BadRequest if preset is malformed", func() {
+				dbInstance.StorePreset(types.Preset{Name: "examplePreset"})
+				preset := []byte(`{"name":"examplePreset","Description: "new description","video": {},"audio": {}}`)
+
+				request, _ := http.NewRequest("PUT", "/presets", bytes.NewBuffer(preset))
+				server.ServeHTTP(response, request)
+
+				Expect(response.Code).To(Equal(http.StatusBadRequest))
+				Expect(response.HeaderMap["Content-Type"][0]).To(Equal("application/json; charset=UTF-8"))
+			})
+		})
 	})
 })

--- a/types/job.go
+++ b/types/job.go
@@ -2,22 +2,25 @@ package types
 
 // These constants are used on the status field of Job type
 const (
-	JobCreated     = "created"
-	JobDownloading = "downloading"
-	JobEncoding    = "encoding"
-	JobUploading   = "uploading"
-	JobFinished    = "finished"
-	JobError       = "error"
+	JobCreated     = JobStatus("created")
+	JobDownloading = JobStatus("downloading")
+	JobEncoding    = JobStatus("encoding")
+	JobUploading   = JobStatus("uploading")
+	JobFinished    = JobStatus("finished")
+	JobError       = JobStatus("error")
 )
+
+// JobStatus represents the status of a job
+type JobStatus string
 
 // Job is the set of parameters of a given job
 type Job struct {
-	ID          string `json:"id"`
-	Source      string `json:"source"`
-	Destination string `json:"destination"`
-	Preset      Preset `json:"preset"`
-	Status      string `json:"status"`
-	Details     string `json:"progress"`
+	ID          string    `json:"id"`
+	Source      string    `json:"source"`
+	Destination string    `json:"destination"`
+	Preset      Preset    `json:"preset"`
+	Status      JobStatus `json:"status"`
+	Details     string    `json:"progress"`
 }
 
 // JobInput stores the information passed from the


### PR DESCRIPTION
Hi @flavioribeiro! 

This PR includes the following commits:

1. **_lib: add JobStatus to represent the status of a job_**: Add `JobStatus` type to avoid any kind of string to be a status of a `Job`;
1. **_rest: read request data from a stream_**: Use `json.Decode` - which reads from a stream - instead of loading the entire json in memory before unmarshaling the content;
1. **_rest: refactor tests_**: Add `Describe`and `Context` for each independent route.

Let me know what you think!
Tks